### PR TITLE
Add option to select different adk

### DIFF
--- a/basic_flow/construct.py.tpl
+++ b/basic_flow/construct.py.tpl
@@ -14,7 +14,7 @@ def construct():
   # Parameters
   #-----------------------------------------------------------------------
 
-  adk_name = 'freepdk-45nm'
+  adk_name = '{{adk_name}}'
   adk_view = 'view-standard'
   design_name = '{{ design_name }}'
   tb_name = f"{design_name}_tb"

--- a/basic_flow/construct.py.tpl
+++ b/basic_flow/construct.py.tpl
@@ -14,7 +14,7 @@ def construct():
   # Parameters
   #-----------------------------------------------------------------------
 
-  adk_name = '{{adk_name}}'
+  adk_name = '{{ adk_name }}'
   adk_view = 'view-standard'
   design_name = '{{ design_name }}'
   tb_name = f"{design_name}_tb"

--- a/pdq/flow_tools/basic_flow.py
+++ b/pdq/flow_tools/basic_flow.py
@@ -17,6 +17,7 @@ class BasicFlowOpts:
     clock_period: float = 2.0
     explore: bool = False
     inline: bool = False
+    adk_name: str = 'freepdk-45nm'
 
 
 def make_basic_flow(ckt: m.DefineCircuitKind, opts: BasicFlowOpts):
@@ -27,6 +28,7 @@ def make_basic_flow(ckt: m.DefineCircuitKind, opts: BasicFlowOpts):
         "clock_period": opts.clock_period,
         "clock_net": clk_name,
         "explore": opts.explore,
+        "adk_name": opts.adk_name,
     }
     builder = TemplatedFlowBuilder()
     builder.set_flow_dir(_BASIC_FLOW_FLOW_DIR)


### PR DESCRIPTION
Adds an --adk_name command line option to choose adks other than freepdk-45nm. Since mflowgen only ships with freepdk, you need to either copy the adk you want to use into the adks dir of the mflowgen installed in your environment, or you can set the MFLOWGEN_PATH environment variable to wherever the adk is located.